### PR TITLE
Evolve empty_message to base_message with randomize option and remove float32 casting.

### DIFF
--- a/craystack/__init__.py
+++ b/craystack/__init__.py
@@ -1,2 +1,2 @@
 from craystack.codecs import *
-from craystack.rans import empty_message
+from craystack.rans import base_message

--- a/craystack/codecs.py
+++ b/craystack/codecs.py
@@ -508,8 +508,7 @@ def std_gaussian_centres(precision):
     if precision in std_gaussian_centres_cache:
         return std_gaussian_centres_cache[precision]
     else:
-        centres = np.float32(
-            norm.ppf((np.arange(1 << precision) + 0.5) / (1 << precision)))
+        centres = norm.ppf((np.arange(1 << precision) + 0.5) / (1 << precision))
         std_gaussian_centres_cache[precision] = centres
         return centres
 

--- a/craystack/codecs_test.py
+++ b/craystack/codecs_test.py
@@ -8,7 +8,7 @@ from craystack import rans
 
 
 def check_codec(head_shape, codec, data):
-    message = cs.empty_message(head_shape)
+    message = cs.base_message(head_shape)
     push, pop = codec
     message_, data_ = pop(push(message, data))
     assert_message_equal(message, message_)
@@ -58,7 +58,7 @@ def test_repeat():
 def test_substack():
     n_data = 100
     prec = 4
-    head, tail = cs.empty_message((4, 4))
+    head, tail = cs.base_message((4, 4))
     head = np.split(head, 2)
     message = head, tail
     data = rng.randint(1 << prec, size=(n_data, 2, 4), dtype='uint64')
@@ -239,7 +239,7 @@ def test_flatten_unflatten():
     n = 100
     shape = (7, 3)
     p = 12
-    state = cs.empty_message(shape)
+    state = cs.base_message(shape)
     some_bits = rng.randint(1 << p, size=(n,) + shape).astype(np.uint64)
     freqs = np.ones(shape, dtype="uint64")
     for b in some_bits:
@@ -267,7 +267,7 @@ def test_resize_head_1d(old_size, new_size, depth=1000):
     p = 8
     bits = np.random.randint(1 << p, size=(depth,) + old_shape, dtype=np.uint64)
 
-    message = cs.empty_message(old_shape)
+    message = cs.base_message(old_shape)
 
     other_bits_push, _ = cs.repeat(cs.Uniform(p), depth)
 
@@ -285,7 +285,7 @@ def test_reshape_head(old_shape, new_shape, depth=1000):
     p = 8
     bits = np.random.randint(1 << p, size=(depth,) + old_shape, dtype=np.uint64)
 
-    message = cs.empty_message(old_shape)
+    message = cs.base_message(old_shape)
 
     other_bits_push, _ = cs.repeat(cs.Uniform(p), depth)
 
@@ -302,7 +302,7 @@ def test_flatten_unflatten(shape, depth=1000):
     p = 8
     bits = np.random.randint(1 << p, size=(depth,) + shape, dtype=np.uint64)
 
-    message = cs.empty_message(shape)
+    message = cs.base_message(shape)
 
     other_bits_push, _ = cs.repeat(cs.Uniform(p), depth)
 
@@ -318,7 +318,7 @@ def test_flatten_rate():
 
     init_data = np.random.randint(1 << 16, size=8 * n, dtype='uint64')
 
-    init_message = cs.empty_message((1,))
+    init_message = cs.base_message((1,))
 
     for datum in init_data:
         init_message = cs.Uniform(16).push(init_message, datum)

--- a/craystack/rans.py
+++ b/craystack/rans.py
@@ -23,8 +23,15 @@ def stack_extend(stack, arr):
 
 def stack_slice(stack, n):
     slc = []
+    shape = stack[0].shape
     while n > 0:
-        arr, stack = stack
+
+        if len(stack) < 2:
+            # empty pop
+            arr, stack = base_message(shape, randomize=True)
+        else:
+            arr, stack = stack
+
         if n >= len(arr):
             slc.append(arr)
             n -= len(arr)

--- a/craystack/rans.py
+++ b/craystack/rans.py
@@ -23,15 +23,8 @@ def stack_extend(stack, arr):
 
 def stack_slice(stack, n):
     slc = []
-    shape = stack[0].shape
     while n > 0:
-
-        if len(stack) < 2:
-            # empty pop
-            arr, stack = base_message(shape, randomize=True)
-        else:
-            arr, stack = stack
-
+        arr, stack = stack
         if n >= len(arr):
             slc.append(arr)
             n -= len(arr)

--- a/craystack/rans.py
+++ b/craystack/rans.py
@@ -7,11 +7,16 @@ import numpy as np
 
 rans_l = 1 << 31  # the lower bound of the normalisation interval
 
-def empty_message(shape):
+def base_message(shape, randomize=False):
     """
-    Returns an empty ANS message of given shape.
+    Returns a base ANS message of given shape. If randomize=True,
+    populates the lower bits of the head with samples from a Bernoulli(1/2)
+    distribution. The tail is empty.
     """
-    return (np.full(shape, rans_l, "uint64"), ())
+    head = np.full(shape, rans_l, "uint64")
+    if randomize:
+        head += np.random.randint(0, rans_l, size=shape, dtype='uint64')
+    return (head, ())
 
 def stack_extend(stack, arr):
     return arr, stack

--- a/craystack/rans.py
+++ b/craystack/rans.py
@@ -16,7 +16,7 @@ def base_message(shape, randomize=False):
     head = np.full(shape, rans_l, "uint64")
     if randomize:
         head += np.random.randint(0, rans_l, size=shape, dtype='uint64')
-    return (head, ())
+    return head, ()
 
 def stack_extend(stack, arr):
     return arr, stack

--- a/craystack/rans_test.py
+++ b/craystack/rans_test.py
@@ -1,7 +1,9 @@
 from craystack import rans
+from numpy.testing import assert_equal
 import numpy as np
 
 rng = np.random.RandomState(0)
+num_lower_bits = int(np.log2(rans.rans_l)) + 1
 
 
 def test_rans():
@@ -55,7 +57,6 @@ def test_base_message():
         return sum([((head >> i) % 2).sum()
                     for i in range(num_lower_bits)])
 
-    num_lower_bits = int(np.log2(rans.rans_l)) + 1
 
     head = rans.base_message(1_000)[0]
     assert calc_num_ones(head) == 1_000
@@ -64,3 +65,28 @@ def test_base_message():
     num_bits = num_lower_bits*100_000
     assert (head_rnd >> (num_lower_bits - 1) == 1).all()
     assert  0.48 < calc_num_ones(head_rnd)/num_bits < 0.52
+
+def test_stack_slice():
+    stack = (np.array([0, 1]).astype('uint64'),
+             (np.array([2, 3]).astype('uint64'),
+              (np.array([4, 5]).astype('uint64'),
+               ())))
+
+    stack, sliced = rans.stack_slice(stack, 1)
+    assert_equal(        sliced, np.array([0   ]))
+    assert_equal(      stack[0], np.array([1   ]))
+    assert_equal(   stack[1][0], np.array([2, 3]))
+    assert_equal(stack[1][1][0], np.array([4, 5]))
+    assert stack[1][1][1] == ()
+
+    stack, sliced = rans.stack_slice(stack, 2)
+    assert_equal(     sliced, np.array([1, 2]))
+    assert_equal(   stack[0], np.array([3   ]))
+    assert_equal(stack[1][0], np.array([4, 5]))
+    assert stack[1][1] == ()
+
+    stack, sliced = rans.stack_slice(stack, 5)
+    assert len(sliced) == 5
+    assert_equal(sliced[3:] >> num_lower_bits-1, np.array([1, 1]))
+    assert_equal(sliced[:3], np.array([3, 4, 5]))
+    assert stack == ()

--- a/craystack/rans_test.py
+++ b/craystack/rans_test.py
@@ -51,13 +51,18 @@ def test_flatten_unflatten():
 
 
 def test_base_message():
+    def calc_num_ones(head):
+        return sum([((head >> i) % 2).sum()
+                    for i in range(num_lower_bits)])
+
     num_lower_bits = int(np.log2(rans.rans_l)) + 1
 
     head = rans.base_message(1_000)[0]
-    num_ones = sum([((head >> i) % 2).sum() for i in range(num_lower_bits)])
+    num_ones = calc_num_ones(head)
     assert num_ones == 1_000
 
     head_rnd = rans.base_message(100_000, randomize=True)[0]
     num_bits = num_lower_bits*100_000
-    num_ones_rnd = sum([((head_rnd >> i) % 2).sum() for i in range(num_lower_bits)])
+    num_ones_rnd = calc_num_ones(head_rnd)
+    assert (head_rnd >> (num_lower_bits - 1) == 1).all()
     assert  0.48 < num_ones_rnd/num_bits < 0.52

--- a/craystack/rans_test.py
+++ b/craystack/rans_test.py
@@ -1,9 +1,7 @@
 from craystack import rans
-from numpy.testing import assert_equal
 import numpy as np
 
 rng = np.random.RandomState(0)
-num_lower_bits = int(np.log2(rans.rans_l)) + 1
 
 
 def test_rans():
@@ -57,6 +55,7 @@ def test_base_message():
         return sum([((head >> i) % 2).sum()
                     for i in range(num_lower_bits)])
 
+    num_lower_bits = int(np.log2(rans.rans_l)) + 1
 
     head = rans.base_message(1_000)[0]
     assert calc_num_ones(head) == 1_000
@@ -65,28 +64,3 @@ def test_base_message():
     num_bits = num_lower_bits*100_000
     assert (head_rnd >> (num_lower_bits - 1) == 1).all()
     assert  0.48 < calc_num_ones(head_rnd)/num_bits < 0.52
-
-def test_stack_slice():
-    stack = (np.array([0, 1]).astype('uint64'),
-             (np.array([2, 3]).astype('uint64'),
-              (np.array([4, 5]).astype('uint64'),
-               ())))
-
-    stack, sliced = rans.stack_slice(stack, 1)
-    assert_equal(        sliced, np.array([0   ]))
-    assert_equal(      stack[0], np.array([1   ]))
-    assert_equal(   stack[1][0], np.array([2, 3]))
-    assert_equal(stack[1][1][0], np.array([4, 5]))
-    assert stack[1][1][1] == ()
-
-    stack, sliced = rans.stack_slice(stack, 2)
-    assert_equal(     sliced, np.array([1, 2]))
-    assert_equal(   stack[0], np.array([3   ]))
-    assert_equal(stack[1][0], np.array([4, 5]))
-    assert stack[1][1] == ()
-
-    stack, sliced = rans.stack_slice(stack, 5)
-    assert len(sliced) == 5
-    assert_equal(sliced[3:] >> num_lower_bits-1, np.array([1, 1]))
-    assert_equal(sliced[:3], np.array([3, 4, 5]))
-    assert stack == ()

--- a/craystack/rans_test.py
+++ b/craystack/rans_test.py
@@ -9,7 +9,7 @@ def test_rans():
     precision = 8
     n_data = 1000
 
-    x = rans.empty_message(shape)
+    x = rans.base_message(shape)
     starts = rng.randint(0, 256, size=(n_data,) + shape).astype("uint64")
     freqs = (rng.randint(1, 256, size=(n_data,) + shape).astype("uint64")
              % (256 - starts))
@@ -29,14 +29,14 @@ def test_rans():
         cf, pop = rans.pop(x, precision)
         assert np.all(start <= cf) and np.all(cf < start + freq)
         x = pop(start, freq)
-    assert np.all(x[0] == rans.empty_message(shape)[0])
+    assert np.all(x[0] == rans.base_message(shape)[0])
 
 
 def test_flatten_unflatten():
     n = 100
     shape = (7, 3)
     prec = 12
-    state = rans.empty_message(shape)
+    state = rans.base_message(shape)
     some_bits = rng.randint(1 << prec, size=(n,) + shape).astype(np.uint64)
     freqs = np.ones(shape, dtype="uint64")
     for b in some_bits:
@@ -48,3 +48,16 @@ def test_flatten_unflatten():
     assert np.all(flat == flat_)
     assert np.all(state[0] == state_[0])
     # assert state[1] == state_[1]
+
+
+def test_base_message():
+    num_lower_bits = int(np.log2(rans.rans_l)) + 1
+
+    head = rans.base_message(1_000)[0]
+    num_ones = sum([((head >> i) % 2).sum() for i in range(num_lower_bits)])
+    assert num_ones == 1_000
+
+    head_rnd = rans.base_message(100_000, randomize=True)[0]
+    num_bits = num_lower_bits*100_000
+    num_ones_rnd = sum([((head_rnd >> i) % 2).sum() for i in range(num_lower_bits)])
+    assert  0.48 < num_ones_rnd/num_bits < 0.52

--- a/craystack/rans_test.py
+++ b/craystack/rans_test.py
@@ -65,28 +65,3 @@ def test_base_message():
     num_bits = num_lower_bits*100_000
     assert (head_rnd >> (num_lower_bits - 1) == 1).all()
     assert  0.48 < calc_num_ones(head_rnd)/num_bits < 0.52
-
-def test_stack_slice():
-    stack = (np.array([0, 1]).astype('uint64'),
-             (np.array([2, 3]).astype('uint64'),
-              (np.array([4, 5]).astype('uint64'),
-               ())))
-
-    stack, sliced = rans.stack_slice(stack, 1)
-    assert_equal(        sliced, np.array([0   ]))
-    assert_equal(      stack[0], np.array([1   ]))
-    assert_equal(   stack[1][0], np.array([2, 3]))
-    assert_equal(stack[1][1][0], np.array([4, 5]))
-    assert stack[1][1][1] == ()
-
-    stack, sliced = rans.stack_slice(stack, 2)
-    assert_equal(     sliced, np.array([1, 2]))
-    assert_equal(   stack[0], np.array([3   ]))
-    assert_equal(stack[1][0], np.array([4, 5]))
-    assert stack[1][1] == ()
-
-    stack, sliced = rans.stack_slice(stack, 5)
-    assert len(sliced) == 5
-    assert_equal(sliced[3:] >> num_lower_bits-1, np.array([1, 1]))
-    assert_equal(sliced[:3], np.array([3, 4, 5]))
-    assert stack == ()

--- a/craystack/rans_test.py
+++ b/craystack/rans_test.py
@@ -53,15 +53,14 @@ def test_flatten_unflatten():
 
 
 def test_base_message():
-    def calc_num_ones(head):
+    def popcount(head):
         return sum([((head >> i) % 2).sum()
                     for i in range(num_lower_bits)])
 
-
     head = rans.base_message(1_000)[0]
-    assert calc_num_ones(head) == 1_000
+    assert popcount(head) == 1_000
 
     head_rnd = rans.base_message(100_000, randomize=True)[0]
     num_bits = num_lower_bits*100_000
     assert (head_rnd >> (num_lower_bits - 1) == 1).all()
-    assert  0.48 < calc_num_ones(head_rnd)/num_bits < 0.52
+    assert  0.48 < popcount(head_rnd)/num_bits < 0.52

--- a/craystack/rans_test.py
+++ b/craystack/rans_test.py
@@ -58,11 +58,9 @@ def test_base_message():
     num_lower_bits = int(np.log2(rans.rans_l)) + 1
 
     head = rans.base_message(1_000)[0]
-    num_ones = calc_num_ones(head)
-    assert num_ones == 1_000
+    assert calc_num_ones(head) == 1_000
 
     head_rnd = rans.base_message(100_000, randomize=True)[0]
     num_bits = num_lower_bits*100_000
-    num_ones_rnd = calc_num_ones(head_rnd)
     assert (head_rnd >> (num_lower_bits - 1) == 1).all()
-    assert  0.48 < num_ones_rnd/num_bits < 0.52
+    assert  0.48 < calc_num_ones(head_rnd)/num_bits < 0.52

--- a/examples/binary_mnist_vae.py
+++ b/examples/binary_mnist_vae.py
@@ -56,7 +56,7 @@ images = np.split(np.reshape(images, (num_images, -1)), num_batches)
 ## Encode
 # Initialize message with some 'extra' bits
 encode_t0 = time.time()
-init_message = cs.empty_message(obs_size + latent_size)
+init_message = cs.base_message(obs_size + latent_size)
 
 # Enough bits to pop a single latent
 other_bits = rng.randint(1 << q_precision, size=latent_shape, dtype=np.uint64)


### PR DESCRIPTION
This PR

1. renames `empty_message` to `base_message`;
2. adds `randomize` option to `base_message`;
3. adds `test_base_message`;
4. removes `np.float32` casting in gaussian buckets.

Not 100% sold on the last line of the test, where we approximate the entropy and assert it to be between 0.48 and 0.52