### PR TITLE
Fix LRU-Cache decorator usage

### DIFF
--- a/craystack/codecs.py
+++ b/craystack/codecs.py
@@ -490,7 +490,7 @@ def LogisticMixture_UnifBins(means, log_scales, logit_probs, coding_prec, bin_pr
     dec_statfun = _ppf_from_cumulative_buckets(cumulative_buckets)
     return NonUniform(enc_statfun, dec_statfun, coding_prec)
 
-@lru_cache
+@lru_cache()
 def std_gaussian_buckets(precision):
     """
     Return the endpoints of buckets partitioning the domain of the prior. Each
@@ -498,7 +498,7 @@ def std_gaussian_buckets(precision):
     """
     return norm.ppf(np.linspace(0, 1, (1 << precision) + 1))
 
-@lru_cache
+@lru_cache()
 def std_gaussian_centres(precision):
     """
     Return the medians of buckets partitioning the domain of the prior. Each


### PR DESCRIPTION
Only writing "@lru_cache" over a function f causes python to call the
decorator with "@lru_cache(f)", which results in the decorator assuming
f to be the max_size argument.

More can be read here: 
https://stackoverflow.com/questions/47218313/use-functools-lru-cache-without-specifying-maxsize-parameter

This fixes a problem with the HiLLoC Notebook, where the 5th cell does not run due to the error described above:
https://colab.research.google.com/drive/11967hjFQczjW21cLLTFhOnTurx3mSBVD#scrollTo=YxbS0ywnKKIg

Tests and example run as before :)
